### PR TITLE
도서, E-Book 삭제 구현

### DIFF
--- a/src/com/test/bookjuck/admin/book/BookDelOk.java
+++ b/src/com/test/bookjuck/admin/book/BookDelOk.java
@@ -1,0 +1,94 @@
+package com.test.bookjuck.admin.book;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.test.bookjuck.dao.BookDAO;
+
+@WebServlet("/admin/book/bookdelok.do")
+public class BookDelOk extends HttpServlet {
+
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+		//1. 데이터 받아오기(seq)
+		//2. DB 작업 -> delete
+		//3. 결과
+		
+		//1.
+		String seq = req.getParameter("seq");
+		
+		//2.
+		//주문내역, 독후감이 있는지?
+		//tblBookOrderDetail
+		//tblBaroOrderDetail
+		//tblReview
+		//있으면 삭제X
+		//없으면 삭제O
+		// - tblInventory, tblBookCart, tblBaroCart, tblBook 순차 삭제
+		
+		BookDAO dao = new BookDAO();
+		
+		boolean isOrderOrReview = dao.isOrderOrReview(seq);
+		
+		if (!isOrderOrReview) {
+			//주문,독후감X -> 삭제O
+			// - tblInventory, tblBookCart, tblBaroCart, tblBook 순차 삭제
+			int result = dao.del(seq);
+			
+			if (result == 1) {
+				resp.setCharacterEncoding("UTF-8");
+				
+				PrintWriter writer = resp.getWriter();
+				
+				writer.print("<html><head><meta charset='UTF-8' /></head><body>");
+				writer.print("<script>");
+				writer.print("alert('도서 삭제 성공!\\n도서 리스트로 이동합니다.');");
+				writer.print("location.href='/bookjuck/admin/book/booklist.do';");
+				writer.print("</script>");
+				writer.print("</body></html>");
+				
+				writer.close();
+				
+			} else {
+				resp.setCharacterEncoding("UTF-8");
+				
+				PrintWriter writer = resp.getWriter();
+				
+				writer.print("<html><head><meta charset='UTF-8' /></head><body>");
+				writer.print("<script>");
+				writer.print("alert('도서 삭제 실패..\\n이전 화면으로 이동합니다.');");
+				writer.print("history.back();");
+				writer.print("</script>");
+				writer.print("</body></html>");
+				
+				writer.close();
+				
+			}
+			
+		} else {
+			//주문, 독후감O -> 삭제X
+			resp.setCharacterEncoding("UTF-8");
+			
+			PrintWriter writer = resp.getWriter();
+			
+			writer.print("<html><head><meta charset='UTF-8' /></head><body>");
+			writer.print("<script>");
+			writer.print("alert('도서 삭제 실패..\\n이전 화면으로 이동합니다.');");
+			writer.print("history.back();");
+			writer.print("</script>");
+			writer.print("</body></html>");
+			
+			writer.close();
+			
+		}
+
+	}
+
+}

--- a/src/com/test/bookjuck/admin/book/EBookDelOk.java
+++ b/src/com/test/bookjuck/admin/book/EBookDelOk.java
@@ -1,0 +1,92 @@
+package com.test.bookjuck.admin.book;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.test.bookjuck.dao.EBookDAO;
+
+@WebServlet("/admin/book/ebookdelok.do")
+public class EBookDelOk extends HttpServlet {
+
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+		//1. 데이터 받아오기(seq)
+		//2. DB 작업 -> delete
+		//3. 결과
+		
+		//1.
+		String seq = req.getParameter("seq");
+		
+		//2.
+		//주문내역이 있는지?
+		//tblEOrderDetail
+		//있으면 삭제X
+		//없으면 삭제O
+		// - tblECart, tblEBook 순차 삭제
+		
+		EBookDAO dao = new EBookDAO();
+		
+		boolean isOrder = dao.isOrder(seq);
+		
+		if (!isOrder) {
+			//주문X -> 삭제O
+			// - tblECart, tblEBook 순차 삭제
+			int result = dao.del(seq);
+			
+			if (result == 1) {
+				resp.setCharacterEncoding("UTF-8");
+				
+				PrintWriter writer = resp.getWriter();
+				
+				writer.print("<html><head><meta charset='UTF-8' /></head><body>");
+				writer.print("<script>");
+				writer.print("alert('E-Book 삭제 성공!\\nE-Book 리스트로 이동합니다.');");
+				writer.print("location.href='/bookjuck/admin/book/ebooklist.do';");
+				writer.print("</script>");
+				writer.print("</body></html>");
+				
+				writer.close();
+				
+			} else {
+				resp.setCharacterEncoding("UTF-8");
+				
+				PrintWriter writer = resp.getWriter();
+				
+				writer.print("<html><head><meta charset='UTF-8' /></head><body>");
+				writer.print("<script>");
+				writer.print("alert('E-Book 삭제 실패..\\n이전 화면으로 이동합니다.');");
+				writer.print("history.back();");
+				writer.print("</script>");
+				writer.print("</body></html>");
+				
+				writer.close();
+				
+			}
+			
+		} else {
+			//주문O -> 삭제X
+			resp.setCharacterEncoding("UTF-8");
+			
+			PrintWriter writer = resp.getWriter();
+			
+			writer.print("<html><head><meta charset='UTF-8' /></head><body>");
+			writer.print("<script>");
+			writer.print("alert('E-Book 삭제 실패..\\n이전 화면으로 이동합니다.');");
+			writer.print("history.back();");
+			writer.print("</script>");
+			writer.print("</body></html>");
+			
+			writer.close();
+			
+		}
+
+	}
+
+}

--- a/src/com/test/bookjuck/dao/BookDAO.java
+++ b/src/com/test/bookjuck/dao/BookDAO.java
@@ -1223,6 +1223,78 @@ public ArrayList<BookDTO> NoCategoryNewBook (HashMap<String, String> map){
 		return null;
 	}
 	
+	//BookDelOk 서블릿 -> 주문 또는 독후감 있는지 확인
+	public boolean isOrderOrReview(String seq) {
+		
+		try {
+			
+			String sql = "select seqBook as seq from (select distinct seqBook from tblBookOrderDetail union all select distinct seqBook from tblBaroOrderDetail union all select distinct seqBook from tblReview) where seqBook = ?";
+			pstat = conn.prepareStatement(sql);
+			pstat.setString(1, seq);
+			rs = pstat.executeQuery();
+			
+			if (rs.next()) {
+				//종이책 상세주문 + 바로드림 상세주문 + 독후감 > 번호 있으면
+				return true;
+			}
+			
+		} catch (Exception e) {
+			System.out.println("BookDAO.isOrderOrReview()");
+			e.printStackTrace();
+		}
+		
+		return false;
+	}
+	
+	//BookDelOk 서블릿 -> 도서 삭제
+	public int del(String seq) {
+		
+		try {
+			// - tblInventory, tblBookCart, tblBaroCart, tblBook 순차 삭제
+			
+			String sql = "delete from tblInventory where seqBook = ?";
+			pstat = conn.prepareStatement(sql);
+			pstat.setString(1, seq);
+			
+			int result = pstat.executeUpdate();
+			
+			if (result == 1) {
+				//도서재고 테이블에서 삭제 성공
+				// -> 종이책 장바구니에서 삭제 (장바구니에 없을 수도 있음)
+				sql = "delete from tblBookCart where seqBook = ?";
+				pstat = conn.prepareStatement(sql);
+				pstat.setString(1, seq);
+				
+				pstat.executeUpdate();
+				
+				//바로드림 장바구니에서 삭제 (장바구니에 없을 수도 있음)
+				sql = "delete from tblBaroCart where seqBook = ?";
+				pstat = conn.prepareStatement(sql);
+				pstat.setString(1, seq);
+					
+				pstat.executeUpdate();
+					
+				//도서테이블에서 삭제
+				sql = "delete from tblBook where seq = ?";
+				pstat = conn.prepareStatement(sql);
+				pstat.setString(1, seq);
+				
+				return pstat.executeUpdate();
+
+			} else {
+				//삭제 실패
+				return 0;
+			}
+			
+			
+		} catch (Exception e) {
+			System.out.println("BookDAO.del()");
+			e.printStackTrace();
+		}
+		
+		return 0;
+	}
+	
 
 	//############# 주혁 끝
 	
@@ -1263,8 +1335,6 @@ public ArrayList<BookDTO> NoCategoryNewBook (HashMap<String, String> map){
 		
 		return null;
 	}
-
-
 	
 	// ############ (조아라) 끝
 

--- a/src/com/test/bookjuck/dao/EBookDAO.java
+++ b/src/com/test/bookjuck/dao/EBookDAO.java
@@ -473,6 +473,56 @@ public class EBookDAO {
 		
 		return 0;
 	}
+
+	//EBookDelOk 서블릿 -> 주문 있는지 확인
+	public boolean isOrder(String seq) {
+		
+		try {
+			
+			String sql = "select distinct seqEBook from tblEOrderDetail where seqEBook = ?";
+			pstat = conn.prepareStatement(sql);
+			pstat.setString(1, seq);
+			rs = pstat.executeQuery();
+			
+			if (rs.next()) {
+				//주문내역 있으면
+				return true;
+			}
+			
+		} catch (Exception e) {
+			System.out.println("EBookDAO.isOrder()");
+			e.printStackTrace();
+		}
+		
+		return false;
+	}
+
+	//EBookDelOk 서블릿 -> EBook 삭제
+	public int del(String seq) {
+
+		try {
+			
+			//EBook 장바구니에서 삭제 (장바구니에 없을 수도 있음)
+			String sql = "delete from tblECart where seqEBook = ?";
+			pstat = conn.prepareStatement(sql);
+			pstat.setString(1, seq);
+			
+			pstat.executeUpdate();
+					
+			//E-Book테이블에서 삭제
+			sql = "delete from tblEBook where seq = ?";
+			pstat = conn.prepareStatement(sql);
+			pstat.setString(1, seq);
+			
+			return pstat.executeUpdate();
+			
+		} catch (Exception e) {
+			System.out.println("EBookDAO.del()");
+			e.printStackTrace();
+		}
+		
+		return 0;
+	}
 	
 	//############# 주혁 끝
 	


### PR DESCRIPTION
1. 도서 삭제 구현
 - 종이책 주문, 바로드림 주문, 독후감 작성한 도서의 경우 삭제 불가능
 - 위에 해당하지 않으면 도서재고, 종이책 장바구니, 바로드림 장바구니, 도서 테이블에서 순차적으로 삭제

2. E-Book 삭제 구현
 - E-Book 주문내역이 있는 경우 삭제 불가능
 - 위에 해당하지 않으면 E-Book 장바구니, E-Book 테이블에서 순차적으로 삭제